### PR TITLE
Fix HACS metadata and docs

### DIFF
--- a/HACS-Compatibility-Analysis.md
+++ b/HACS-Compatibility-Analysis.md
@@ -32,15 +32,15 @@ ufo-r11-smartir/                         # Git repository root
 ```
 
 ### 3. 🏷️ **Git Tag Management** (High Priority)
-- **Current Status**: No Git tags exist (`.git/refs/tags/` is empty)
-- **Manifest Version**: `1.0.0` with no corresponding Git tag
-- **HACS Behavior**: Shows version "00ef676" (commit hash) instead of semantic version
-- **Impact**: HACS cannot validate version compatibility
+- **Current Status**: Git tags from `v0.1.0` to `v1.0.7` exist
+- **Manifest Version**: `1.0.7` matching the latest tag
+- **HACS Behavior**: Uses semantic version tags correctly
+- **Impact**: Version compatibility validated by HACS
 
 ### 4. 🔗 **Repository URL Inconsistencies** (Medium Priority)
 **Manifest References**:
-- `documentation`: `https://github.com/UFO-R11/ufo-r11-smartir`
-- `issue_tracker`: `https://github.com/UFO-R11/ufo-r11-smartir/issues`
+- `documentation`: `https://github.com/Eetuheino03/UFO-R11-point`
+- `issue_tracker`: `https://github.com/Eetuheino03/UFO-R11-point/issues`
 
 **Actual Repository**: `https://github.com/Eetuheino03/UFO-R11-point.git`
 
@@ -222,8 +222,8 @@ integration-name/
 ### 🏷️ **Git Tag Creation**
 ```bash
 # Create and push version tag
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.0.7
+git push origin v1.0.7
 
 # Verify tag creation
 git tag -l
@@ -231,8 +231,9 @@ git tag -l
 
 ### 🔧 **Quick HACS Test Setup**
 1. Fix the `FanMode` import issue
-2. Create v1.0.0 Git tag
-3. Test HACS installation with custom repository URL
+2. Ensure `hacs.json` is present
+3. Create v1.0.7 Git tag
+4. Test HACS installation with custom repository URL
 
 ## Strategic Recommendation
 

--- a/custom_components/ufo_r11_smartir/README.md
+++ b/custom_components/ufo_r11_smartir/README.md
@@ -87,7 +87,7 @@ The learning interface provides an intuitive step-by-step process:
 1. Open HACS in your Home Assistant
 2. Go to "Integrations"
 3. Click the three dots menu and select "Custom repositories"
-4. Add this repository URL: `https://github.com/UFO-R11/ufo-r11-smartir`
+4. Add this repository URL: `https://github.com/Eetuheino03/UFO-R11-point`
 5. Select "Integration" as the category
 6. Click "Add"
 7. Search for "UFO-R11 SmartIR" and install
@@ -408,9 +408,9 @@ The integration provides comprehensive REST API endpoints:
 
 ## Support
 
-- **Documentation**: [GitHub Wiki](https://github.com/UFO-R11/ufo-r11-smartir/wiki)
-- **Issues**: [GitHub Issues](https://github.com/UFO-R11/ufo-r11-smartir/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/UFO-R11/ufo-r11-smartir/discussions)
+- **Documentation**: [GitHub Wiki](https://github.com/Eetuheino03/UFO-R11-point/wiki)
+- **Issues**: [GitHub Issues](https://github.com/Eetuheino03/UFO-R11-point/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/Eetuheino03/UFO-R11-point/discussions)
 - **Community**: [Home Assistant Community Forum](https://community.home-assistant.io)
 
 ## License

--- a/custom_components/ufo_r11_smartir/manifest.json
+++ b/custom_components/ufo_r11_smartir/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ufo_r11_smartir",
   "name": "ufo_r11_smartir",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "documentation": "https://github.com/Eetuheino03/UFO-R11-point",
   "issue_tracker": "https://github.com/Eetuheino03/UFO-R11-point/issues",
   "dependencies": [

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "UFO-R11 SmartIR",
+  "content_in_root": false,
+  "domains": ["ufo_r11_smartir"],
+  "homeassistant": "2023.0.0",
+  "render_readme": true
+}


### PR DESCRIPTION
## Summary
- add missing `hacs.json`
- update manifest version to match latest tag
- fix README HACS links
- note new tag and URLs in compatibility analysis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zeroconf')*

------
https://chatgpt.com/codex/tasks/task_e_68417050e14c832f806f66cb54b4b7ed