### PR TITLE
Fix frontend panel registration

### DIFF
--- a/custom_components/ufo_r11_smartir/frontend_panel.py
+++ b/custom_components/ufo_r11_smartir/frontend_panel.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from homeassistant.components import frontend
+from homeassistant.components import frontend, panel_custom
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -28,43 +28,40 @@ async def async_register_panel(hass: HomeAssistant) -> None:
         # Register the frontend panel
         panel_registered_successfully = False
         
-        # Try the older method first, potentially for older HA versions
-        if hasattr(frontend, 'async_register_built_in_panel') and \
-           frontend.async_register_built_in_panel is not None:
+        # Register using the built-in 'custom' panel mechanism
+        if hasattr(frontend, "async_register_built_in_panel") and frontend.async_register_built_in_panel:
             _LOGGER.debug("Attempting to register panel using async_register_built_in_panel")
             try:
                 await frontend.async_register_built_in_panel(
                     hass,
-                    component_name=DOMAIN, # Used for namespacing
+                    component_name="custom",
                     sidebar_title="UFO-R11 SmartIR",
                     sidebar_icon="mdi:remote",
-                    frontend_url_path=DOMAIN, # URL path for the panel
+                    frontend_url_path=DOMAIN,
                     config={
-                        "_panel_custom": { # Standard structure for custom panels
+                        "_panel_custom": {
                             "name": f"panel-custom-{DOMAIN.replace('_', '-')}",
                             "js_url": f"/api/{DOMAIN}/static/ufo-r11-panel.js",
                             "css_url": f"/api/{DOMAIN}/static/ufo-r11-styles.css",
-                        }
+                        },
                     },
+                    require_admin=False,
                 )
                 panel_registered_successfully = True
                 _LOGGER.info("Panel registered using async_register_built_in_panel")
             except Exception as e_builtin:
                 _LOGGER.warning(
-                    "async_register_built_in_panel failed: %s. Will try async_register_panel if available.", e_builtin
+                    "async_register_built_in_panel failed: %s", e_builtin
                 )
         
         # If the older method was not available, was None, or failed, try the newer method
-        if not panel_registered_successfully and \
-           hasattr(frontend, 'async_register_panel') and \
-           frontend.async_register_panel is not None:
-            _LOGGER.debug(
-                "Attempting to register panel using async_register_panel."
-            )
+        if not panel_registered_successfully and hasattr(panel_custom, "async_register_panel"):
+            _LOGGER.debug("Attempting to register panel using panel_custom.async_register_panel")
             try:
-                await frontend.async_register_panel(
+                await panel_custom.async_register_panel(
                     hass,
                     frontend_url_path=DOMAIN,
+                    webcomponent_name=f"panel-custom-{DOMAIN.replace('_', '-')}",
                     sidebar_title="UFO-R11 SmartIR",
                     sidebar_icon="mdi:remote",
                     module_url=f"/api/{DOMAIN}/static/ufo-r11-panel.js",
@@ -72,10 +69,9 @@ async def async_register_panel(hass: HomeAssistant) -> None:
                     require_admin=False,
                 )
                 panel_registered_successfully = True
-                _LOGGER.info("Panel registered using async_register_panel")
+                _LOGGER.info("Panel registered using panel_custom.async_register_panel")
             except Exception as e_panel:
-                _LOGGER.error("async_register_panel also failed: %s", e_panel)
-                # If this also fails, we will fall through to the final error message / raise
+                _LOGGER.error("panel_custom.async_register_panel failed: %s", e_panel)
         
         if panel_registered_successfully:
             _LOGGER.info("UFO-R11 SmartIR frontend panel registered successfully")
@@ -83,7 +79,7 @@ async def async_register_panel(hass: HomeAssistant) -> None:
             # This 'else' is reached if neither method was available (was None) or both failed
             _LOGGER.error(
                 "Failed to register frontend panel. Neither async_register_built_in_panel "
-                "nor async_register_panel were available and not None, or both attempts failed. "
+                "nor panel_custom.async_register_panel succeeded. "
                 "Check Home Assistant version compatibility and frontend component status. "
                 "Review previous logs for specific errors from registration attempts."
             )


### PR DESCRIPTION
## Summary
- fix logic for registering the custom frontend panel
- fallback to panel_custom when built-in registration fails

## Testing
- `python3 test_syntax_fix.py`
- `python3 simple_frontend_validation.py` *(fails: Import mismatch)*
- `python3 test_attribute_fix.py` *(fails: No module named 'homeassistant')*
- `python3 test_critical_issues_diagnosis.py`
- `python3 test_final_import_fix.py`
- `python3 test_frontend_api_diagnosis.py`
- `python3 test_frontend_fix_validation.py`
- `python3 test_frontend_import.py` *(fails: No module named 'homeassistant')*
- `python3 test_ir_core.py`
- `python3 test_ir_system.py` *(fails: No module named 'homeassistant')*
- `python3 test_critical_fixes_validation.py`
- `python3 test_critical_issues_diagnosis.py`

------
https://chatgpt.com/codex/tasks/task_e_684178d8d480832f904f1fc8ff7869f2